### PR TITLE
Updates to Saving and Live Preview for Web Safe Fonts

### DIFF
--- a/acf-google-font-selector-field/trunk/acf-google_font_selector-v4.php
+++ b/acf-google-font-selector-field/trunk/acf-google_font_selector-v4.php
@@ -182,7 +182,9 @@ class acf_field_google_font_selector extends acf_field {
 
 				<?php $font = str_replace( ' ', '+', $current_font_family ); ?>
 				<div class='acfgfs-preview'>
-					<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=<?php echo $font ?>">
+					<?php if ( ! acfgfs_check_web_safe_fonts($current_font_family) ) : ?>
+						<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=<?php echo $font ?>">
+					<?php endif; ?>
 
 					<div style='font-family:<?php echo $current_font_family ?>'>
 						<?php _e( 'This is a preview of the selected font', 'acf-google-font-selector-field' ) ?>

--- a/acf-google-font-selector-field/trunk/acf-google_font_selector-v5.php
+++ b/acf-google-font-selector-field/trunk/acf-google_font_selector-v5.php
@@ -133,7 +133,9 @@ class acf_field_google_font_selector extends acf_field {
 
 				<?php $font = str_replace( ' ', '+', $current_font_family ); ?>
 				<div class='acfgfs-preview'>
-					<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=<?php echo $font ?>">
+					<?php if ( ! acfgfs_check_web_safe_fonts($current_font_family) ) : ?>
+						<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=<?php echo $font ?>">
+					<?php endif; ?>
 
 					<div style='font-family:<?php echo $font ?>'>
 						<?php _e( 'This is a preview of the selected font', 'acf-google-font-selector-field' ) ?>

--- a/acf-google-font-selector-field/trunk/functions.php
+++ b/acf-google-font-selector-field/trunk/functions.php
@@ -134,7 +134,7 @@ function acfgfs_get_font_dropdown_array( $field = null ) {
  */
 function acfgfs_get_font( $font ) {
     $fonts = acfgfs_get_fonts();
-    return $fonts[$font];
+    return isset($fonts[$font]) ? $fonts[$font] : false;
 }
 
 /**
@@ -230,6 +230,20 @@ function acfgfs_get_web_safe_fonts() {
     return $web_safe;
 }
 
+/**
+ * Web Safe Font Check
+ *
+ * Checks to see if Current Font is a Web Safe Font
+ *
+ * @return array Boolean true if web safe false if otherwise
+ * @author Parapxl
+ * @since 3.0.0
+ *
+ */
+function acfgfs_check_web_safe_fonts( $font ) {
+    $web_safe = acfgfs_get_web_safe_fonts();
+    return array_search($font, $web_safe) !== false ? true : false;
+}
 
 /**
  * Font Variant Array
@@ -245,7 +259,7 @@ function acfgfs_get_web_safe_fonts() {
  */
 function acfgfs_get_font_variant_array( $font ) {
     $font = acfgfs_get_font( $font );
-    return $font['variants'];
+    return isset($fonts[$font]) ? $fonts[$font] : false;
 }
 
 
@@ -263,7 +277,7 @@ function acfgfs_get_font_variant_array( $font ) {
  */
 function acfgfs_get_font_subset_array( $font ) {
     $font = acfgfs_get_font( $font );
-    return $font['subsets'];
+    return isset($font['subsets']) ? $font['subsets'] : false;
 }
 
 /**

--- a/acf-google-font-selector-field/trunk/js/input.js
+++ b/acf-google-font-selector-field/trunk/js/input.js
@@ -53,12 +53,14 @@
                             container.find( '.acfgfs-loader').hide();
                             variants.html( response.variants );
                             subsets.html( response.subsets );
-
-							preview_text = jQuery('#acfgfs-preview div').html();
-							font = new_font.replace( ' ', '+' );
-							container.find('.acfgfs-preview').html('<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=' + font + '"><div style="font-family:' + new_font + '"></div>')
-							jQuery('#acfgfs-preview div').html(preview_text)
-
+                            
+                            preview_text = jQuery('.acfgfs-preview div').html();
+                            font         = new_font.replace(' ', '+');
+                            web_safe     = ['Georgia', 'Palatino Linotype', 'Book Antiqua', 'Palatino', 'Times New Roman', 'Times', 'Arial', 'Helvetica', 'Arial Black', 'Gadget', 'Impact', 'Charcoal', 'Lucida Sans Unicode', 'Lucida Grande', 'Tahoma', 'Geneva', 'Trebuchet MS', 'Helvetica', 'Verdana', 'Geneva', 'Courier New', 'Courier', 'Lucida Console', 'Monaco'];
+                            link         = web_safe.indexOf(new_font) < 0 ? '<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=' + font + '">' : '';
+                            
+                            container.find('.acfgfs-preview').html(link + '<div style="font-family:' + new_font + '"></div>');
+                            jQuery('.acfgfs-preview div').html(preview_text);
                         }
                     });
                 });
@@ -113,10 +115,11 @@
                             container.find( '.acfgfs-loader').hide();
                             variants.html( response.variants );
                             subsets.html( response.subsets );
-
-							font = new_font.replace( ' ', '+' );
-							container.find('.acfgfs-preview').html('<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=' + font + '"><div style="font-family:' + font + '">This is new a preview of the selected font</div>')
-
+                            
+                            font     = new_font.replace(' ', '+');
+                            web_safe = ['Georgia', 'Palatino Linotype', 'Book Antiqua', 'Palatino', 'Times New Roman', 'Times', 'Arial', 'Helvetica', 'Arial Black', 'Gadget', 'Impact', 'Charcoal', 'Lucida Sans Unicode', 'Lucida Grande', 'Tahoma', 'Geneva', 'Trebuchet MS', 'Helvetica', 'Verdana', 'Geneva', 'Courier New', 'Courier', 'Lucida Console', 'Monaco'];
+                            link     = web_safe.indexOf(new_font) < 0 ? '<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=' + font + '">' : '';
+                            container.find('.acfgfs-preview').html(link + '<div style="font-family:' + new_font + '">This is a new preview of the selected font</div>');
                         }
                     });
                 });


### PR DESCRIPTION
When trying to interact with Web Safe Fonts in debug mode plugin throws a warning about font not being found in the list of Google Fonts. I have added in checks to resolve this.

Additionally I have added in a check for when to include the Google Font link when using or switching to a web safe font.

I also fixed a small issue where the preview section was being called by the id selector instead of class selector. Now the preview text updates as it should.